### PR TITLE
feat: add new color for editor line number

### DIFF
--- a/themes/Keepcalm-color-theme.json
+++ b/themes/Keepcalm-color-theme.json
@@ -25,7 +25,7 @@
     "statusBarItem.hoverBackground": "#1d191a",
     "statusBarItem.activeBackground": "#191517",
     "editorRuler.foreground": "#2a2d31",
-    "editorLineNumber.foreground": "#3e4651",
+    "editorLineNumber.foreground": "#52627b",
     "list.activeSelectionForeground": "#E7E8EA",
     "list.activeSelectionBackground": "#2e2c2d",
     "list.focusOutline": "#3d444e",

--- a/themes/Keepcalm-color-theme.json
+++ b/themes/Keepcalm-color-theme.json
@@ -25,7 +25,7 @@
     "statusBarItem.hoverBackground": "#1d191a",
     "statusBarItem.activeBackground": "#191517",
     "editorRuler.foreground": "#2a2d31",
-    "editorLineNumber.foreground": "#52627b",
+    "editorLineNumber.foreground": "#6e7681",
     "list.activeSelectionForeground": "#E7E8EA",
     "list.activeSelectionBackground": "#2e2c2d",
     "list.focusOutline": "#3d444e",


### PR DESCRIPTION
Hi @sgmonda, you can try this new settings, I have changed the value for `editorLineNumber.foreground`, due to I feel that the color is a lot light, I belive that it isn't a lot visual. I left some screenshot, could you try this commit and let me know?

Thanks you! And good you for this theme. 

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img src="https://github.com/sgmonda/keepcalm/assets/3200844/fea709d4-a58e-42bf-8f45-058876e48210" alt="Before" /></td><td><img src="https://github.com/sgmonda/keepcalm/assets/3200844/a5a51072-ffa5-4fab-bef9-f60aaab4efc3" alt="After" /></td></tr>



